### PR TITLE
Add Machine Unlearning Comparator to benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@
 | Zhang et al. | [Does your LLM truly unlearn? An embarrassingly simple approach to recover unlearned knowledge](https://arxiv.org/abs/2410.16454) | arXiv |
 | Zhao et al. | [Separable Multi-Concept Erasure from Diffusion Models](https://arxiv.org/abs/2402.05947) | arXiv |
 | Zuo et al. | [Machine unlearning through fine-grained model parameters perturbation](https://arxiv.org/abs/2401.04385) | arXiv |
-|||
-| Jaeung Lee | [Machine Unlearning Comparator](https://github.com/gnueaj/Machine-Unlearning-Comparator) | Github |
 
 ### 2023
 | Author(s) | Title | Venue |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 [OpenUnlearning](https://github.com/locuslab/open-unlearning)
 
+[Machine Unlearning Comparator](https://github.com/gnueaj/Machine-Unlearning-Comparator)
+
 ## Papers
 
 [2025](#2025) &nbsp;


### PR DESCRIPTION
  ## Description
  This PR adds the Unlearning Comparator to the Benchmarks section - a visual analytics system for comparative evaluation of machine unlearning methods.

  ## Details
  - **Paper**: [arXiv:2508.12730](https://arxiv.org/abs/2508.12730)
  - **Demo**: [Live Application](https://gnueaj.github.io/Machine-Unlearning-Comparator/)
  - **Repository**: [GitHub](https://github.com/gnueaj/Machine-Unlearning-Comparator)

  The tool provides:
  - Systematic comparison of MU methods
  - Visual analytics for accuracy, efficiency, and privacy evaluation
  - Interactive privacy audits with MIA simulations
  - Support for multiple unlearning methods (FT, GA, RL, SCRUB, SalUn, and Custom Methods)

  This complements the existing Open Unlearning framework by providing visual evaluation capabilities.